### PR TITLE
fix: 인터벌, 이벤트가 제대로 삭제되지 않는 현상 수정

### DIFF
--- a/src/classes/manager/event.manager.js
+++ b/src/classes/manager/event.manager.js
@@ -63,16 +63,18 @@ class EventManager {
     });
 
     this.eventEmitter.on('onChangePhase', (params) => {
-      const {currentGame} = params
+      const { currentGame } = params;
       const tmp = currentGame.currentPhase;
       currentGame.currentPhase = currentGame.nextPhase;
-      currentGame.nextPhase = tmp
+      currentGame.nextPhase = tmp;
       const responseNotification = phaseUpdateNotification(currentGame);
       currentGame.users.forEach((user) => {
-        user.socket.write(createResponse(PACKET_TYPE.PHASE_UPDATE_NOTIFICATION, 0, responseNotification))
+        user.socket.write(
+          createResponse(PACKET_TYPE.PHASE_UPDATE_NOTIFICATION, 0, responseNotification),
+        );
       });
 
-      userUpdateNotification(currentGame.users)
+      userUpdateNotification(currentGame.users);
       currentGame.changePhase();
     });
   }
@@ -80,6 +82,11 @@ class EventManager {
   // 이벤트 예약
   // interval 매니저의 그 형태임
   scheduleEvent(userId, eventName, timeout, params = {}) {
+    if (this.events.has(userId) && this.events.get(userId).has(eventName)) {
+      console.log(`[DEL] ${userId}: ${eventName}`);
+      this.cancelEvent(userId, eventName);
+    }
+
     if (!this.events.has(userId)) {
       this.events.set(userId, new Map());
     }
@@ -109,8 +116,8 @@ class EventManager {
   }
 
   clearAll() {
-    console.log('삭제 전 이벤트 매니저:')
-    console.dir(this.events, {depth:null})
+    console.log('삭제 전 이벤트 매니저:');
+    console.dir(this.events, { depth: null });
     this.events.forEach((e) => {
       e.forEach((id) => {
         clearTimeout(id);
@@ -118,10 +125,9 @@ class EventManager {
     });
 
     this.events.clear();
-    console.log('삭제 후 이벤트 매니저:')
-    console.dir(this.events, {depth:null})
+    console.log('삭제 후 이벤트 매니저:');
+    console.dir(this.events, { depth: null });
   }
-
 }
 
 export default EventManager;

--- a/src/classes/model/game.class.js
+++ b/src/classes/model/game.class.js
@@ -5,7 +5,7 @@ import { phaseUpdateNotification } from '../../utils/notification/phaseUpdate.no
 import { createResponse } from '../../utils/response/createResponse.js';
 import EventManager from '../manager/event.manager.js';
 import userUpdateNotification from '../../utils/notification/userUpdate.notification.js';
-import { intervalManager } from '../manager/interval.manager.js';
+import IntervalManager from '../manager/interval.manager.js';
 
 // 1. 방 === 게임 <--- 기존 강의나 전 팀플에서 썼던 game세션과 game 클래스 같이 써도 되지않을까?
 // IntervalManager 게임 세션별로 하나씩 두고 얘가 낮밤 관리하게
@@ -32,8 +32,15 @@ class Game {
 
     // this.eventQueue = [];
     this.events = new EventManager();
+    this.intervalManager = new IntervalManager();
     this.events.init();
     this.day = 1;
+  }
+
+  release() {
+    this.intervalManager.clearAll();
+    this.events.clearAll();
+    this.intervalManager = null;
   }
 
   returnCardToDeck(cardType) {
@@ -42,7 +49,7 @@ class Game {
 
   changePhase() {
     const time = phaseTime[this.currentPhase];
-    this.events.scheduleEvent(this.id, 'onChangePhase', time, {currentGame: this})
+    this.events.scheduleEvent(this.id, 'onChangePhase', time, { currentGame: this });
     // setTimeout(() => {
     //   const tmp = this.currentPhase;
     //   this.currentPhase = this.nextPhase;
@@ -111,13 +118,12 @@ class Game {
   }
 
   removeCardFromFleaMarketDeck() {
-    this.fleaMarketDeck.splice(0, 1)
+    this.fleaMarketDeck.splice(0, 1);
   }
 
   gameStart() {
     this.state = Packets.RoomStateType.PREPARE;
-    intervalManager.addGameEndNotification(this);
-
+    this.intervalManager.addGameEndNotification(this);
   }
 }
 

--- a/src/handler/room/gameStart.handler.js
+++ b/src/handler/room/gameStart.handler.js
@@ -1,4 +1,3 @@
-import { intervalManager } from '../../classes/manager/interval.manager.js';
 import { PACKET_TYPE } from '../../constants/header.js';
 import { characterPositions } from '../../init/loadPositions.js';
 import { Packets } from '../../init/loadProtos.js';
@@ -66,7 +65,7 @@ export const gameStartHandler = (socket, payload) => {
   console.log('마스크군 존재 여부:', isMask);
   if (isMask) {
     console.log('마스크군 존재');
-    intervalManager.addDeathPlayer(currentGame); //마스크군이 존재할 때
+    currentGame.intervalManager.addDeathPlayer(currentGame); //마스크군이 존재할 때
   }
   // 핑크 체크
   const isPink = currentGame.users.find(
@@ -74,7 +73,7 @@ export const gameStartHandler = (socket, payload) => {
   );
   if (isPink) {
     console.log('핑크군 존재');
-    intervalManager.addHandCardCheck(currentGame);
+    currentGame.intervalManager.addHandCardCheck(currentGame);
   }
 
   // 페이즈 시작

--- a/src/sessions/game.session.js
+++ b/src/sessions/game.session.js
@@ -16,7 +16,12 @@ export const removeGameSession = (gameId) => {
     return null;
   }
 
-  return gameSession.splice(index, 1)[0];
+  const game = gameSession.splice(index, 1)[0];
+  if (game) {
+    game.release();
+  }
+
+  return game;
 };
 
 export const findGameById = (gameId) => {

--- a/src/utils/notification/gameEnd.notification.js
+++ b/src/utils/notification/gameEnd.notification.js
@@ -3,7 +3,6 @@ import { Packets } from '../../init/loadProtos.js';
 import { createResponse } from '../response/createResponse.js';
 import { removeGameSession } from '../../sessions/game.session.js';
 import { roomManager } from '../../classes/manager/room.manager.js';
-import { intervalManager } from '../../classes/manager/interval.manager.js';
 
 export const gameEndNotification = (room) => {
   const survivor = [];
@@ -23,7 +22,7 @@ export const gameEndNotification = (room) => {
 
   if (!isTarget && !isBodyguard && !isHitman) {
     //싸이코패스 승리
-    console.log("싸이코패스 승리")
+    console.log('싸이코패스 승리');
     const winners = room.users.filter(
       (user) => user.characterData.roleType === Packets.RoleType.PSYCHOPATH,
     );
@@ -36,7 +35,7 @@ export const gameEndNotification = (room) => {
     };
   } else if (!isHitman && !isPsychopath) {
     //타겟 & 보디가드 승리
-    console.log("타겟 & 보디가드 승리")
+    console.log('타겟 & 보디가드 승리');
     const winners = room.users.filter(
       (user) =>
         user.characterData.roleType === Packets.RoleType.TARGET ||
@@ -51,7 +50,7 @@ export const gameEndNotification = (room) => {
     };
   } else if (!isTarget) {
     //히트맨 승리
-    console.log("히트맨 승리")
+    console.log('히트맨 승리');
     const winners = room.users.filter(
       (user) => user.characterData.roleType === Packets.RoleType.HITMAN,
     );
@@ -63,21 +62,18 @@ export const gameEndNotification = (room) => {
       },
     };
   }
-  console.log("인터벌 작동 - ",responsePayload)
+  console.log('인터벌 작동 - ', responsePayload);
   if (responsePayload) {
-    // room.events.clearAll();
-    room.events.cancelEvent(room.id, 'onChangePhase')
-    intervalManager.removeInterval(room.id, 'game');
-
     // intervalManager.clearAll();
     roomManager.deleteRoom(room.id);
     room.users.forEach((user) => {
       user.socket.write(createResponse(PACKET_TYPE.GAME_END_NOTIFICATION, 0, responsePayload));
     });
     //게임 종료 시 인터벌 제거, 세션 삭제
-    
+
+    // removeGameSession에서 인터벌과 이벤트를 비워주는 release 메서드 호출
     removeGameSession(room.id);
-    console.log("게임 세션 삭제")
+    console.log('게임 세션 삭제');
   }
 };
 


### PR DESCRIPTION
게임 클래스 내부에서 인터벌을 관리하게 하고, `game.session.js` 파일의 `removeGameSession` 함수에서 게임 인스턴스를 삭제할 때 비워주는 메서드(`release`)를 호출하게 변경했습니다.

페이즈 변경 이벤트도 이벤트 호출 후에 `events`에서 바로 삭제되지 않는 것을 확인했습니다. (게임이 종료되었는데 `updatePhase`가 호출되던 현상)
따라서 이벤트를 재등록 할 때 명시적으로 삭제한 후 다시 등록하는 로직을 추가했습니다.

인터벌 매니저 클래스의 메서드도 조금 직관적이게 재작성 했습니다.
리뷰 부탁드립니다.

---
### EDIT:

한 명만 강제 종료한 경우에 인터벌이 바로 비워져서 그런지 게임 종료가 되지 않는 현상이 발견되었습니다... 흑흑
머지는 하지 말아주세요.
코멘트로 리뷰만 부탁드립니다..