### PR TITLE
fix: 인터벌 매니저, 이벤트 매니저, 카드 삭제 등 수정

### DIFF
--- a/src/classes/manager/event.manager.js
+++ b/src/classes/manager/event.manager.js
@@ -63,16 +63,18 @@ class EventManager {
     });
 
     this.eventEmitter.on('onChangePhase', (params) => {
-      const {currentGame} = params
+      const { currentGame } = params;
       const tmp = currentGame.currentPhase;
       currentGame.currentPhase = currentGame.nextPhase;
-      currentGame.nextPhase = tmp
+      currentGame.nextPhase = tmp;
       const responseNotification = phaseUpdateNotification(currentGame);
       currentGame.users.forEach((user) => {
-        user.socket.write(createResponse(PACKET_TYPE.PHASE_UPDATE_NOTIFICATION, 0, responseNotification))
+        user.socket.write(
+          createResponse(PACKET_TYPE.PHASE_UPDATE_NOTIFICATION, 0, responseNotification),
+        );
       });
 
-      userUpdateNotification(currentGame.users)
+      userUpdateNotification(currentGame.users);
       currentGame.changePhase();
     });
   }
@@ -80,6 +82,11 @@ class EventManager {
   // 이벤트 예약
   // interval 매니저의 그 형태임
   scheduleEvent(userId, eventName, timeout, params = {}) {
+    if (this.events.has(userId) && this.events.get(userId).has(eventName)) {
+      console.log(`[DEL] ${userId}: ${eventName}`);
+      this.cancelEvent(userId, eventName);
+    }
+
     if (!this.events.has(userId)) {
       this.events.set(userId, new Map());
     }
@@ -109,8 +116,8 @@ class EventManager {
   }
 
   clearAll() {
-    console.log('삭제 전 이벤트 매니저:')
-    console.dir(this.events, {depth:null})
+    console.log('삭제 전 이벤트 매니저:');
+    console.dir(this.events, { depth: null });
     this.events.forEach((e) => {
       e.forEach((id) => {
         clearTimeout(id);
@@ -118,10 +125,9 @@ class EventManager {
     });
 
     this.events.clear();
-    console.log('삭제 후 이벤트 매니저:')
-    console.dir(this.events, {depth:null})
+    console.log('삭제 후 이벤트 매니저:');
+    console.dir(this.events, { depth: null });
   }
-
 }
 
 export default EventManager;

--- a/src/classes/manager/event.manager.js
+++ b/src/classes/manager/event.manager.js
@@ -87,12 +87,20 @@ class EventManager {
       this.cancelEvent(userId, eventName);
     }
 
+    if (!this.eventEmitter) {
+      return;
+    }
+
     if (!this.events.has(userId)) {
       this.events.set(userId, new Map());
     }
 
     const userEvent = this.events.get(userId);
     const eventId = setTimeout(() => {
+      if (!this.eventEmitter) {
+        return;
+      }
+
       // data를 넘겨받을 필요가 있으면 추가하기
       this.eventEmitter.emit(eventName, params);
       userEvent.delete(eventName);

--- a/src/classes/model/game.class.js
+++ b/src/classes/model/game.class.js
@@ -41,6 +41,8 @@ class Game {
     this.intervalManager.clearAll();
     this.events.clearAll();
     this.intervalManager = null;
+    this.events.eventEmitter = null;
+    this.events = null;
   }
 
   returnCardToDeck(cardType) {

--- a/src/classes/model/game.class.js
+++ b/src/classes/model/game.class.js
@@ -5,7 +5,7 @@ import { phaseUpdateNotification } from '../../utils/notification/phaseUpdate.no
 import { createResponse } from '../../utils/response/createResponse.js';
 import EventManager from '../manager/event.manager.js';
 import userUpdateNotification from '../../utils/notification/userUpdate.notification.js';
-import { intervalManager } from '../manager/interval.manager.js';
+import IntervalManager from '../manager/interval.manager.js';
 
 // 1. 방 === 게임 <--- 기존 강의나 전 팀플에서 썼던 game세션과 game 클래스 같이 써도 되지않을까?
 // IntervalManager 게임 세션별로 하나씩 두고 얘가 낮밤 관리하게
@@ -32,8 +32,15 @@ class Game {
 
     // this.eventQueue = [];
     this.events = new EventManager();
+    this.intervalManager = new IntervalManager();
     this.events.init();
     this.day = 1;
+  }
+
+  release() {
+    this.intervalManager.clearAll();
+    this.events.clearAll();
+    this.intervalManager = null;
   }
 
   returnCardToDeck(cardType) {
@@ -42,7 +49,7 @@ class Game {
 
   changePhase() {
     const time = phaseTime[this.currentPhase];
-    this.events.scheduleEvent(this.id, 'onChangePhase', time, {currentGame: this})
+    this.events.scheduleEvent(this.id, 'onChangePhase', time, { currentGame: this });
     // setTimeout(() => {
     //   const tmp = this.currentPhase;
     //   this.currentPhase = this.nextPhase;
@@ -111,13 +118,12 @@ class Game {
   }
 
   removeCardFromFleaMarketDeck() {
-    this.fleaMarketDeck.splice(0, 1)
+    this.fleaMarketDeck.splice(0, 1);
   }
 
   gameStart() {
     this.state = Packets.RoomStateType.PREPARE;
-    intervalManager.addGameEndNotification(this);
-
+    this.intervalManager.addGameEndNotification(this);
   }
 }
 

--- a/src/classes/model/user.class.js
+++ b/src/classes/model/user.class.js
@@ -252,8 +252,10 @@ class User {
     // 존재하지 않으면 addHandCard({ type: newType, count: 1})
     // count-- => count === 0 객체를 아예 삭제
     if (index !== -1) {
-      const cnt = this.characterData.handCards[index].count--;
+      const cnt = --this.characterData.handCards[index].count;
+      // --this.characterDataHandCards[index].count;
       this.decreaseHandCardsCount(); // removeHandCard에서 카드 카운트를 한 번 더해버려 손패 개수가 카드 한 장 사용할 때마다 2장씩 빠짐
+      // if (this.characterDataHandCards[index].count === 0)
       if (cnt === 0) {
         // 남은 카드 없음
         this.characterData.handCards.splice(index, 1);
@@ -271,7 +273,7 @@ class User {
 
   removeDebuffCard(debuff) {
     const index = this.characterData.debuffs.findIndex((element) => element === debuff);
-    console.log('debuff 삭제:',this.characterData.debuffs[index])
+    console.log('debuff 삭제:', this.characterData.debuffs[index]);
     if (index !== -1) {
       this.characterData.debuffs.splice(index, 1);
     }

--- a/src/db/database.js
+++ b/src/db/database.js
@@ -34,4 +34,38 @@ const pools = {
   USER_DB: createPool(database.USER_DB),
 };
 
+const getConnection = async () => {
+  try {
+    const conn = await pools.USER_DB.getConnection();
+    return conn;
+  } catch (err) {
+    if (conn) {
+      conn.rollback();
+    }
+
+    console.error(err);
+    return null;
+  } finally {
+    if (conn) {
+      await conn.release();
+    }
+  }
+};
+
+const transaction = async (queries) => {
+  let conn = null;
+  try {
+    conn = await getConnection();
+    await conn.beginTransaction();
+
+    const result = await queries();
+
+    await conn.commit();
+    return result;
+  } catch (err) {
+    console.error(err);
+    return null;
+  }
+};
+
 export default pools;

--- a/src/handler/room/gameStart.handler.js
+++ b/src/handler/room/gameStart.handler.js
@@ -1,4 +1,3 @@
-import { intervalManager } from '../../classes/manager/interval.manager.js';
 import { PACKET_TYPE } from '../../constants/header.js';
 import { characterPositions } from '../../init/loadPositions.js';
 import { Packets } from '../../init/loadProtos.js';
@@ -66,7 +65,7 @@ export const gameStartHandler = (socket, payload) => {
   console.log('마스크군 존재 여부:', isMask);
   if (isMask) {
     console.log('마스크군 존재');
-    intervalManager.addDeathPlayer(currentGame); //마스크군이 존재할 때
+    currentGame.intervalManager.addDeathPlayer(currentGame); //마스크군이 존재할 때
   }
   // 핑크 체크
   const isPink = currentGame.users.find(
@@ -74,7 +73,7 @@ export const gameStartHandler = (socket, payload) => {
   );
   if (isPink) {
     console.log('핑크군 존재');
-    intervalManager.addHandCardCheck(currentGame);
+    currentGame.intervalManager.addHandCardCheck(currentGame);
   }
 
   // 페이즈 시작

--- a/src/handler/room/prepare.handler.js
+++ b/src/handler/room/prepare.handler.js
@@ -41,14 +41,6 @@ export const gamePrepareHandler = (socket, payload) => {
     currentGame.gameStart();
     console.log('현재 게임 정보:', currentGame);
 
-    /* TODO:
-            *  1. 캐릭터 셔플(CharacterType) - 완료
-            *  2. 덱 셔플 후 카드 배분 - 캐릭터 HP만큼(user.hp) user.addHandCards(card)
-                    - Packets.CardType
-            *  3. 역할 배분(RoleType) - 완료
-            *  4. CharacterType에 맞게 hp 설정 - 완료
-            */
-
     const inGameUsers = currentGame.users;
 
     // 캐릭터 셔플
@@ -132,34 +124,33 @@ export const gamePrepareHandler = (socket, payload) => {
       for (let i = 0; i < user.characterData.hp; i++) {
         const card = deck.shift();
         tmp.push(card);
-        // user.addHandCard(card); // card === type
+        user.addHandCard(card); // card === type
         // { type: card, count: 1}
-        // user.increaseHandCardsCount();  // 원본 살려야 하는 코드
+        user.increaseHandCardsCount(); // 원본 살려야 하는 코드
       }
       // 2. 한 번에 추가
       const result = transformData(tmp);
-      // user.characterData.handCards = result;
+      user.characterData.handCards = result;
       // WARN: Test code
-      // 너무 많이 넣으면 UI가 안뜸(카드가 다 안뜸)
-      user.characterData.handCards = [
-        { type: Packets.CardType.BBANG, count: 2 },
-        { type: Packets.CardType.ABSORB, count: 2 },
-        { type: Packets.CardType.HALLUCINATION, count: 2 },
-        // { type: Packets.CardType.SHIELD, count: 2 },
-        { type: Packets.CardType.FLEA_MARKET, count: 1 },
-        { type: Packets.CardType.AUTO_RIFLE, count: 1 },
-        // { type: Packets.CardType.GUERRILLA, count: 1 },
-        // { type: Packets.CardType.CALL_119, count: 1 },
-        // { type: Packets.CardType.HAND_GUN, count: 1 },
-        { type: Packets.CardType.DESERT_EAGLE, count: 1 },
-        // { type: Packets.CardType.LASER_POINTER, count: 1 },
-        { type: Packets.CardType.RADAR, count: 1 },
-        { type: Packets.CardType.AUTO_SHIELD, count: 1 },
-        { type: Packets.CardType.CONTAINMENT_UNIT, count: 1 },
-        { type: Packets.CardType.SATELLITE_TARGET, count: 1 },
-        { type: Packets.CardType.BOMB, count: 1 },
-      ];
-      user.characterData.handCardsCount = 14;
+      // user.characterData.handCards = [
+      // { type: Packets.CardType.BIG_BBANG, count: 2 },
+      //   { type: Packets.CardType.ABSORB, count: 2 },
+      // { type: Packets.CardType.HALLUCINATION, count: 2 },
+      // { type: Packets.CardType.SHIELD, count: 2 },
+      //   { type: Packets.CardType.FLEA_MARKET, count: 1 },
+      //   { type: Packets.CardType.AUTO_RIFLE, count: 1 },
+      //   { type: Packets.CardType.GUERRILLA, count: 1 },
+      //   { type: Packets.CardType.CALL_119, count: 1 },
+      //   { type: Packets.CardType.HAND_GUN, count: 1 },
+      //   { type: Packets.CardType.DESERT_EAGLE, count: 1 },
+      //   { type: Packets.CardType.LASER_POINTER, count: 1 },
+      //   { type: Packets.CardType.RADAR, count: 1 },
+      //   { type: Packets.CardType.AUTO_SHIELD, count: 1 },
+      //   { type: Packets.CardType.CONTAINMENT_UNIT, count: 1 },
+      //   { type: Packets.CardType.SATELLITE_TARGET, count: 1 },
+      //   { type: Packets.CardType.BOMB, count: 1 },
+      // ];
+      // user.characterData.handCardsCount = 4;
       // console.log(user.id, '의 handCards:', user.characterData.handCards);
     });
 

--- a/src/sessions/game.session.js
+++ b/src/sessions/game.session.js
@@ -16,7 +16,12 @@ export const removeGameSession = (gameId) => {
     return null;
   }
 
-  return gameSession.splice(index, 1)[0];
+  const game = gameSession.splice(index, 1)[0];
+  if (game) {
+    game.release();
+  }
+
+  return game;
 };
 
 export const findGameById = (gameId) => {

--- a/src/utils/notification/gameEnd.notification.js
+++ b/src/utils/notification/gameEnd.notification.js
@@ -3,7 +3,6 @@ import { Packets } from '../../init/loadProtos.js';
 import { createResponse } from '../response/createResponse.js';
 import { removeGameSession } from '../../sessions/game.session.js';
 import { roomManager } from '../../classes/manager/room.manager.js';
-import { intervalManager } from '../../classes/manager/interval.manager.js';
 
 export const gameEndNotification = (room) => {
   const survivor = [];
@@ -23,7 +22,7 @@ export const gameEndNotification = (room) => {
 
   if (!isTarget && !isBodyguard && !isHitman) {
     //싸이코패스 승리
-    console.log("싸이코패스 승리")
+    console.log('싸이코패스 승리');
     const winners = room.users.filter(
       (user) => user.characterData.roleType === Packets.RoleType.PSYCHOPATH,
     );
@@ -36,7 +35,7 @@ export const gameEndNotification = (room) => {
     };
   } else if (!isHitman && !isPsychopath) {
     //타겟 & 보디가드 승리
-    console.log("타겟 & 보디가드 승리")
+    console.log('타겟 & 보디가드 승리');
     const winners = room.users.filter(
       (user) =>
         user.characterData.roleType === Packets.RoleType.TARGET ||
@@ -51,7 +50,7 @@ export const gameEndNotification = (room) => {
     };
   } else if (!isTarget) {
     //히트맨 승리
-    console.log("히트맨 승리")
+    console.log('히트맨 승리');
     const winners = room.users.filter(
       (user) => user.characterData.roleType === Packets.RoleType.HITMAN,
     );
@@ -63,21 +62,18 @@ export const gameEndNotification = (room) => {
       },
     };
   }
-  console.log("인터벌 작동 - ",responsePayload)
+  console.log('인터벌 작동 - ', responsePayload);
   if (responsePayload) {
-    // room.events.clearAll();
-    room.events.cancelEvent(room.id, 'onChangePhase')
-    intervalManager.removeInterval(room.id, 'game');
-
     // intervalManager.clearAll();
     roomManager.deleteRoom(room.id);
     room.users.forEach((user) => {
       user.socket.write(createResponse(PACKET_TYPE.GAME_END_NOTIFICATION, 0, responsePayload));
     });
     //게임 종료 시 인터벌 제거, 세션 삭제
-    
+
+    // removeGameSession에서 인터벌과 이벤트를 비워주는 release 메서드 호출
     removeGameSession(room.id);
-    console.log("게임 세션 삭제")
+    console.log('게임 세션 삭제');
   }
 };
 


### PR DESCRIPTION
게임 클래스 내부에서 인터벌을 관리하게 하고, game.session.js 파일의 removeGameSession 함수에서 게임 인스턴스를 삭제할 때 비워주는 메서드(release)를 호출하게 변경했습니다.

페이즈 변경 이벤트도 이벤트 호출 후에 events에서 바로 삭제되지 않는 것을 확인했습니다. (게임이 종료되었는데 updatePhase가 호출되던 현상)
따라서 이벤트를 재등록 할 때 명시적으로 삭제한 후 다시 등록하는 로직을 추가했습니다.

인터벌 매니저 클래스의 메서드도 조금 직관적이게 재작성 했습니다.

---

## 추가 수정

1. 카드 삭제가 제대로 이루어지지 않던 문제 수정
2. 이벤트 매니저가 `release` 된 이후에 이미 발동 된 이벤트가 있는 경우 발생하던 문제 수정