### PR TITLE
fix: 핸드 카드 리팩토링, 페이즈 버그 수정, 페이즈 인터벌 매니저를 통해 관리하게 변경

### DIFF
--- a/src/classes/manager/event.manager.js
+++ b/src/classes/manager/event.manager.js
@@ -60,22 +60,6 @@ class EventManager {
       warningNoti();
       bombTimer();
     });
-
-    this.eventEmitter.on('onChangePhase', (params) => {
-      const { currentGame } = params;
-      const tmp = currentGame.currentPhase;
-      currentGame.currentPhase = currentGame.nextPhase;
-      currentGame.nextPhase = tmp;
-      const responseNotification = phaseUpdateNotification(currentGame);
-      currentGame.users.forEach((user) => {
-        user.socket.write(
-          createResponse(PACKET_TYPE.PHASE_UPDATE_NOTIFICATION, 0, responseNotification),
-        );
-      });
-
-      userUpdateNotification(currentGame.users);
-      currentGame.changePhase();
-    });
   }
 
   // 이벤트 예약

--- a/src/classes/manager/interval.manager.js
+++ b/src/classes/manager/interval.manager.js
@@ -39,8 +39,8 @@ class IntervalManager {
   removeInterval(id, eventName) {
     const intervals = this.intervals.get(id);
     if (intervals && intervals.has(eventName)) {
-      clearInterval(intervals.get(type));
-      intervals.delete(type);
+      clearInterval(intervals.get(eventName));
+      intervals.delete(eventName);
       console.log(`[CANCEL EVENT] ${id}: ${eventName} 취소됨.`);
       return;
     }

--- a/src/classes/model/characterData.class.js
+++ b/src/classes/model/characterData.class.js
@@ -11,7 +11,7 @@ class CharacterData {
     this.equips = []; // int32
     this.debuffs = []; // int32
     // 가능하면 Map으로 관리하는 것이 좋음. 카드 찾을 때 O(1)과 O(n)의 차이
-    this.handCards = []; // CardData Object
+    this.handCards = new Map(); // CardData Object
     this.bbangCount = 0;
     this.handCardsCount = 0;
     this.alive = true;

--- a/src/classes/model/game.class.js
+++ b/src/classes/model/game.class.js
@@ -1,7 +1,11 @@
+import { createResponse } from '../../utils/response/createResponse.js';
 import phaseTime from '../../constants/phaseTime.js';
 import { Packets } from '../../init/loadProtos.js';
+import { phaseUpdateNotification } from '../../utils/notification/phaseUpdate.notification.js';
+import userUpdateNotification from '../../utils/notification/userUpdate.notification.js';
 import EventManager from '../manager/event.manager.js';
 import IntervalManager from '../manager/interval.manager.js';
+import { PACKET_TYPE } from '../../constants/header.js';
 
 // 1. 방 === 게임 <--- 기존 강의나 전 팀플에서 썼던 game세션과 game 클래스 같이 써도 되지않을까?
 // IntervalManager 게임 세션별로 하나씩 두고 얘가 낮밤 관리하게
@@ -48,7 +52,29 @@ class Game {
 
   changePhase() {
     const time = phaseTime[this.currentPhase];
-    this.events.scheduleEvent(this.id, 'onChangePhase', time, { currentGame: this });
+    const currentGame = this;
+    this.intervalManager.removeInterval(this.id, 'gameChangePhase');
+    this.intervalManager.addInterval(
+      this.id,
+      () => {
+        try {
+          const tmp = currentGame.currentPhase;
+          currentGame.currentPhase = currentGame.nextPhase;
+          currentGame.nextPhase = tmp;
+          const responseNotification = phaseUpdateNotification(currentGame);
+          currentGame.users.forEach((user) => {
+            user.socket.write(
+              createResponse(PACKET_TYPE.PHASE_UPDATE_NOTIFICATION, 0, responseNotification),
+            );
+          });
+          userUpdateNotification(currentGame.users);
+        } catch (err) {
+          console.error(err);
+        }
+      },
+      time,
+      'gameChangePhase',
+    );
   }
 
   isFullRoom() {

--- a/src/classes/model/user.class.js
+++ b/src/classes/model/user.class.js
@@ -228,41 +228,58 @@ class User {
   }
 
   addHandCard(addCard) {
-    const index = this.characterData.handCards.findIndex((card) => card.type === addCard);
-
-    // { type: enum, count: 1} enum값이 handCards에 존재하면 count++
-    // 존재하지 않으면 addHandCard({ type: newType, count: 1})
-    if (index !== -1) {
-      const cnt = this.characterData.handCards[index].count++;
-    } else {
-      const tmp = {
-        type: addCard,
-        count: 1,
-      };
-      this.characterData.handCards.push(tmp);
-    }
+    this.characterData.handCards.set(addCard, (this.characterData.handCards.get(addCard) || 0) + 1);
     this.increaseHandCardsCount();
+    // const index = this.characterData.handCards.findIndex((card) => card.type === addCard);
+    //
+    // // { type: enum, count: 1} enum값이 handCards에 존재하면 count++
+    // // 존재하지 않으면 addHandCard({ type: newType, count: 1})
+    // if (index !== -1) {
+    //   const cnt = this.characterData.handCards[index].count++;
+    // } else {
+    //   const tmp = {
+    //     type: addCard,
+    //     count: 1,
+    //   };
+    //   this.characterData.handCards.push(tmp);
+    // }
+  }
+
+  // 있으면 해당 카드의 count를 없으면 0를 반환함
+  findCard(cardType) {
+    return this.characterData.handCards.get(cardType) || 0;
   }
 
   selectRandomHandCard() {
-    const randomIndex = Math.floor(Math.random() * this.characterData.handCards.length);
-    return this.characterData.handCards[randomIndex].type;
+    const handCards = this.getHandCardsToArray();
+    const randomIndex = Math.floor(Math.random() * handCards.length);
+    // return handCards[randomIndex]; // [cardType, count] 형태의 배열 반환
+    return handCards[randomIndex].type; // cardType
+
+    // const randomIndex = Math.floor(Math.random() * this.characterData.handCards.length);
+    // return this.characterData.handCards[randomIndex].type;
   }
 
   removeHandCard(usingCard) {
-    const index = this.characterData.handCards.findIndex((card) => card.type === usingCard);
-
-    // { type: enum, count: 1} enum값이 handCards에 존재하면 count++
-    // 존재하지 않으면 addHandCard({ type: newType, count: 1})
-    // count-- => count === 0 객체를 아예 삭제
-    if (index !== -1) {
-      const cnt = --this.characterData.handCards[index].count;
-      this.decreaseHandCardsCount();
-      if (cnt === 0) {
-        // 남은 카드 없음
-        this.characterData.handCards.splice(index, 1);
-      }
+    const count = this.characterData.handCards.get(usingCard);
+    if (count === 1) {
+      this.characterData.handCards.delete(usingCard);
+    } else {
+      this.characterData.handCards.set(usingCard, count - 1);
     }
+
+    this.decreaseHandCardsCount();
+    // const index = this.characterData.handCards.findIndex((card) => card.type === usingCard);
+    //
+    // // count-- => count === 0 객체를 아예 삭제
+    // if (index !== -1) {
+    //   const cnt = --this.characterData.handCards[index].count;
+    //   this.decreaseHandCardsCount();
+    //   if (cnt === 0) {
+    //     // 남은 카드 없음
+    //     this.characterData.handCards.splice(index, 1);
+    //   }
+    // }
   }
 
   removeEquipCard(equip) {
@@ -281,19 +298,15 @@ class User {
   }
 
   hasShieldCard() {
-    const shieldCard = this.characterData.handCards.find((card) => {
-      return card.type === Packets.CardType.SHIELD;
-    });
+    const shieldCard = this.characterData.handCards.get(Packets.CardType.SHIELD);
 
     return shieldCard ? true : false;
   }
 
   hasBbangCard() {
-    const shieldCard = this.characterData.handCards.find((card) => {
-      return card.type === Packets.CardType.BBANG;
-    });
+    const bbangCard = this.characterData.handCards.get(Packets.CardType.BBANG);
 
-    return shieldCard ? true : false;
+    return bbangCard ? true : false;
   }
 
   // 이거 안쓰지 않나
@@ -337,6 +350,15 @@ class User {
     this.characterData.stateInfo.stateTargetUserId = targetUserId;
   }
 
+  getHandCardsToArray() {
+    const result = Array.from(this.characterData.handCards.entries(), ([key, value]) => ({
+      type: key,
+      count: value,
+    }));
+    console.log(this.nickname, result);
+    return result;
+  }
+
   makeRawObject() {
     return {
       id: this.id,
@@ -355,7 +377,7 @@ class User {
         },
         equips: this.characterData.equips,
         debuffs: this.characterData.debuffs,
-        handCards: this.characterData.handCards,
+        handCards: this.getHandCardsToArray(),
         bbangCount: this.characterData.bbangCount,
         handCardsCount: this.characterData.handCardsCount,
       },

--- a/src/handler/card/destroyCard.handler.js
+++ b/src/handler/card/destroyCard.handler.js
@@ -20,9 +20,7 @@ export const destroyCardHandler = (socket, payload) => {
 
   const responsePayload = {
     destroyCardResponse: {
-      handCards: cardDestroyUser.characterData.handCards.map((card) => {
-        return { type: card.type, count: card.count };
-      }),
+      handCards: cardDestroyUser.getHandCardsToArray(),
     },
   };
 

--- a/src/handler/card/normal/bbangCard.handler.js
+++ b/src/handler/card/normal/bbangCard.handler.js
@@ -119,13 +119,14 @@ const autoShieldCheck = (targetUser, currentGame) => {
 
 //캐릭터 특성 - 상어군, 장비 특성 - 레이저
 const needShieldCheck = (cardUsingUser, targetUser, currentGame, needShield) => {
-  const shieldCount = targetUser.characterData.handCards.find((card) => {
-    if (card.type === Packets.CardType.SHIELD) {
-      return card.count;
-    } else {
-      return 0;
-    }
-  });
+  // const shieldCount = targetUser.characterData.handCards.find((card) => {
+  //   if (card.type === Packets.CardType.SHIELD) {
+  //     return card.count;
+  //   } else {
+  //     return 0;
+  //   }
+  // });
+  const shieldCount = targetUser.findCard(Packets.CardType.SHIELD);
 
   if (shieldCount < needShield) {
     targetUser.decreaseHp(cardUsingUser.damage);

--- a/src/handler/game/reaction.handler.js
+++ b/src/handler/game/reaction.handler.js
@@ -71,13 +71,10 @@ const characterTypeGetCard = (user, targetUser, game, lostHp) => {
 
   if (user.characterData.characterType === Packets.CharacterType.PINK_SLIME) {
     if (targetUser.characterData.handCardsCount !== 0) {
-      const card =
-        targetUser.characterData.handCards[
-          Math.floor(Math.random() * targetUser.characterData.handCardsCount)
-        ];
+      const card = targetUser.selectRandomHandCard();
 
-      targetUser.removeHandCard(card.type);
-      user.addHandCard(card.type);
+      targetUser.removeHandCard(card);
+      user.addHandCard(card);
     }
   }
 };

--- a/src/utils/notification/deadCheck.notification.js
+++ b/src/utils/notification/deadCheck.notification.js
@@ -23,7 +23,7 @@ const characterTypeGetCard = (game, deathUser) => {
     userUpdateNotification(game.users);
     return;
   }
-  const deathUserHandCards = deathUser.characterData.handCards;
+  const deathUserHandCards = deathUser.getHandCardsToArray();
   const handCardsLength = deathUserHandCards.length;
   const deathUserEquips = deathUser.characterData.equips;
   const equipCardsLength = deathUserEquips.length;

--- a/src/utils/notification/phaseUpdate.notification.js
+++ b/src/utils/notification/phaseUpdate.notification.js
@@ -16,59 +16,43 @@ export const phaseUpdateNotification = (game) => {
         if (selectedPositions.size === inGameUsers.length) {
           break;
         }
-        // 낮인 경우만 위치가 다시 셔플돼서 updatePosition
-        // 밤에는 현재 위치
-        if (game.currentPhase === Packets.PhaseType.DAY) {
-          const inGameUsers = game.users;
-
-          // 랜덤 위치 뽑기
-          const selectedPositions = new Set();
-          while (true) {
-            if (selectedPositions.size === inGameUsers.length) {
-              break;
-            }
-
-            const randId = Math.floor(Math.random() * 20);
-            selectedPositions.add(characterPositions[randId]);
-          }
-
-          // 선택된 위치 정보는 JSON의 id고, 그걸 접속한 유저의 아이디로 치환
-          const posArr = [...selectedPositions];
-          for (let i = 0; i < inGameUsers.length; i++) {
-            posArr[i].id = inGameUsers[i].id;
-            // UPDATE: 초기 좌표 세팅
-            inGameUsers[i].updatePosition(posArr[i].x, posArr[i].y);
-          }
-
-          // 낮이 시작되면 카드 버려주기(어차피 hp보다 적거나 같으면 안버리면 됨)
-          inGameUsers.forEach((user) => {
-            const userOverHandedCount = user.overHandedCount();
-
-            if (userOverHandedCount > 0) {
-              for (let i = 0; i < userOverHandedCount; i++) {
-                // 오버한 갯수만큼 랜덤하게 손패 삭제
-                const randomCard =
-                  user.characterData.handCards[
-                    Math.floor(Math.random() * user.characterData.handCards.length)
-                  ];
-                user.removeHandCard(randomCard.type); // <- randomCard 값이 안읽히는 것 같음
-              }
-            }
-          });
-
-          // 빵야 카운트 리셋, 카드 두 개씩 주기
-          inGameUsers.forEach((user) => {
-            const gainCards = game.deck.splice(0, 2);
-            gainCards.forEach((card) => user.addHandCard(card));
-            user.resetBbangCount();
-          });
-
-          // 감옥 로직
-          prisonLogic(inGameUsers);
-          // 위성 로직
-          satelliteLogic(inGameUsers);
-        }
+        const randId = Math.floor(Math.random() * 20);
+        selectedPositions.add(characterPositions[randId]);
       }
+
+      // 선택된 위치 정보는 JSON의 id고, 그걸 접속한 유저의 아이디로 치환
+      const posArr = [...selectedPositions];
+      for (let i = 0; i < inGameUsers.length; i++) {
+        posArr[i].id = inGameUsers[i].id;
+        // UPDATE: 초기 좌표 세팅
+        inGameUsers[i].updatePosition(posArr[i].x, posArr[i].y);
+      }
+
+      // 낮이 시작되면 카드 버려주기(어차피 hp보다 적거나 같으면 안버리면 됨)
+      inGameUsers.forEach((user) => {
+        const userOverHandedCount = user.overHandedCount();
+
+        if (userOverHandedCount > 0) {
+          for (let i = 0; i < userOverHandedCount; i++) {
+            // 오버한 갯수만큼 랜덤하게 손패 삭제
+            const randomCard = user.selectRandomHandCard();
+            console.log(randomCard, '선택됨');
+            user.removeHandCard(randomCard); // <- randomCard 값이 안읽히는 것 같음
+          }
+        }
+      });
+
+      // 빵야 카운트 리셋, 카드 두 개씩 주기
+      inGameUsers.forEach((user) => {
+        const gainCards = game.deck.splice(0, 2);
+        gainCards.forEach((card) => user.addHandCard(card));
+        user.resetBbangCount();
+      });
+
+      // 감옥 로직
+      prisonLogic(inGameUsers);
+      // 위성 로직
+      satelliteLogic(inGameUsers);
     }
 
     const time = Date.now() + phaseTime[game.currentPhase];


### PR DESCRIPTION
제가 merge할 때 실수를 했었나봅니다...
### `phaseUpdate.notification.js` 기존 코드 (dev 브랜치)
```javascript
try {
    // 낮인 경우만 위치가 다시 셔플돼서 updatePosition
    // 밤에는 현재 위치
    if (game.currentPhase === Packets.PhaseType.DAY) {
      const inGameUsers = game.getAliveUsers();

      // 랜덤 위치 뽑기
      const selectedPositions = new Set();
      while (true) {
        if (selectedPositions.size === inGameUsers.length) {
          break;
        }
        // 낮인 경우만 위치가 다시 셔플돼서 updatePosition
        // 밤에는 현재 위치
        if (game.currentPhase === Packets.PhaseType.DAY) {
          const inGameUsers = game.users;

          // 랜덤 위치 뽑기
          const selectedPositions = new Set();
          while (true) {
            if (selectedPositions.size === inGameUsers.length) {
              break;
            }

            const randId = Math.floor(Math.random() * 20);
            selectedPositions.add(characterPositions[randId]);
          }
...
```

잘 보시면 `if`와 `while` 로직이 중첩되어있는 것을 볼 수 있습니다.
로그를 찍어봤더니 카드 삭제랑 카드 추가가 열댓번 반복되길래 뭐지? 싶어서 자세히 확인했더니 이런 결과가...
이제 페이즈 변경도 잘 됩니다..

그리고 handCards를 맵으로 바꾼 것도 정상 작동 합니다.
기존 로직이 `addHandCard`나 `removeHandCard` 등 메서드를 사용했어서 수월하게 리팩토링 했습니다.
`user.characterData.handCards`에 직접 접근하던 로직들만 살짝 메서드를 사용하게 수정했습니다.